### PR TITLE
feat!: add fish_path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,28 @@
 ```lua
 require("packer").use({ "mtoohey31/cmp-fish", ft = "fish" })
 
+require("cmp_fish").setup()
 cmp.setup({
   sources = cmp.config.sources({
     { name = 'fish' }
   })
+})
+```
+
+## Configuration
+
+The default configuration looks like this:
+
+```lua
+{
+    fish_path = "fish"
+}
+```
+
+You can override the default configuration through `setup`:
+
+```lua
+require("cmp_fish").setup({
+    fish_path = "/usr/bin/fish"
 })
 ```

--- a/after/plugin/cmp_fish.lua
+++ b/after/plugin/cmp_fish.lua
@@ -1,1 +1,0 @@
-require'cmp'.register_source('fish', require'cmp_fish'.new())

--- a/lua/cmp_fish.lua
+++ b/lua/cmp_fish.lua
@@ -1,10 +1,23 @@
 -- cspell:ignore jobstart jobstop chansend nvim
 
-local source = {}
+local source = {
+	config = {
+		fish_path = "fish",
+	},
+}
+
+--- Sets up the source.
+---
+--- This function must be called before use.
+source.setup = function(config)
+	config = config or {}
+	source.config = vim.tbl_extend("force", source.config, config)
+	require("cmp").register_source("fish", source.new())
+end
 
 local create_job = function(self)
-  return vim.fn.jobstart({ "fish", "-ic", 'while read val -P ""; complete -C "$val"; end' }, {
-    shell = "fish",
+  return vim.fn.jobstart({ self.config.fish_path, "-ic", 'while read val -P ""; complete -C "$val"; end' }, {
+    shell = self.config.fish_path,
     on_stdout = function(_, data)
       for _, line in ipairs(data) do
         if line == "" and self.callback ~= nil then


### PR DESCRIPTION
This parameter lets the user configure the path to the Fish shell, which comes in handy in environments where PATH configuration is not readily available.